### PR TITLE
fix: Return exception message instead of redirecting to login

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - docker compose -f docker-compose-prod.yml down
 
 ### 맥 로컬에서 실행
-- export $(grep -v '^#' .env | xargs) && docker-compose -f docker-compose-dev.yml up --build -d
+- export $(grep -v '^#' .env.dev | xargs) && docker-compose -f docker-compose-dev.yml up --build -d
 - docker-compose -f docker-compose-dev.yml down
 
 ### 윈도우 로컬에서 실행

--- a/src/main/java/cafeLogProject/cafeLog/common/auth/oauth2/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/auth/oauth2/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,26 @@
+package cafeLogProject.cafeLog.common.auth.oauth2;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+        response.setContentType("application/json; charset=UTF-8");
+
+        String json = String.format("{\"status\": %d, \"message\": \"%s\"}",
+                HttpServletResponse.SC_BAD_REQUEST,
+                "정의되지 않은 엔트리포인트입니다.");
+
+        response.getWriter().write(json);
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
@@ -6,9 +6,9 @@ import cafeLogProject.cafeLog.common.auth.jwt.JWTLoginHandler;
 import cafeLogProject.cafeLog.common.auth.jwt.JWTLogoutFilter;
 import cafeLogProject.cafeLog.common.auth.jwt.JWTUtil;
 import cafeLogProject.cafeLog.common.auth.jwt.token.JWTTokenService;
+import cafeLogProject.cafeLog.common.auth.oauth2.CustomAuthenticationEntryPoint;
 import cafeLogProject.cafeLog.common.auth.oauth2.CustomOAuth2UserService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.autoconfigure.session.DefaultCookieSerializerCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -28,6 +28,7 @@ public class SecurityConfig {
     private final JWTLoginHandler loginHandler;
     private final JWTUtil jwtUtil;
     private final JWTTokenService tokenService;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
     public static final String[] whiteList = {
             "/api/auth/login",
             "/api/auth/check",
@@ -83,6 +84,10 @@ public class SecurityConfig {
                         .requestMatchers(whiteList).permitAll()
                         .requestMatchers("/api/**", "/logout").authenticated()
                         .anyRequest().denyAll());
+
+        http
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint));
 
         http
                 .sessionManagement((auth) -> auth

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/GlobalExceptionHandler.java
@@ -1,7 +1,6 @@
 package cafeLogProject.cafeLog.common.exception;
 
 import cafeLogProject.cafeLog.common.dto.ApiErrorResponse;
-import cafeLogProject.cafeLog.common.exception.CafeAppException;
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;


### PR DESCRIPTION
## 정의되지 않은 엔드포인트로 요청시 로그인 페이지로 리다이렉트 되는 문제 해결

- AuthenticationEntryPoint 를 CustomAuthenticationEntryPoint 로 구현하여 예외메시지 작성
- SecurityConfig 에 exceptionHandling 를 추가