### PR TITLE
fix: User NickName Duplicate Check

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -1,0 +1,7 @@
+services:
+
+  app:
+    image: acoldbottle/backend-app:latest  # Docker Hub에서 사용할 이미지
+    ports:
+      - "8080:8080"
+    env_file: .env.prod

--- a/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
@@ -34,9 +34,10 @@ public class UserController {
     }
 
     @GetMapping("/users/check")
-    public ResponseEntity<IsExistNicknameRes> isExistNickname(@RequestParam @Valid String nickname) {
+    public ResponseEntity<IsExistNicknameRes> isExistNickname(@RequestParam @Valid String nickname,
+                                                              @AuthenticationPrincipal CustomOAuth2User user) {
 
-        IsExistNicknameRes isExist = userService.isExistNickname(nickname);
+        IsExistNicknameRes isExist = userService.isExistNickname(user.getName(), nickname);
         return ResponseEntity.ok(isExist);
     }
 

--- a/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
@@ -39,11 +39,11 @@ public class UserService {
     }
 
     @Transactional
-    public void updateUser(String userName, UserUpdateReq userUpdateReq) {
+    public void updateUser(String username, UserUpdateReq userUpdateReq) {
 
-        User user = userRepository.findByUsername(userName).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
 
-        validateNickname(userName, userUpdateReq);
+        validateNickname(username, userUpdateReq);
 
         user.updateUserNickname(userUpdateReq.getNickName());
         user.updateUserIntroduce(userUpdateReq.getIntroduce());
@@ -51,18 +51,18 @@ public class UserService {
         userRepository.save(user);
     }
 
-    public IsExistNicknameRes isExistNickname(String nickname) {
+    public IsExistNicknameRes isExistNickname(String username, String nickname) {
 
-        Boolean isExist = userRepository.existsByNickname(nickname);
-
-        if (isExist) {
-            return new IsExistNicknameRes(nickname, true);
+        if (!userRepository.existsNicknameExcludingSelf(username, nickname)) {
+            return new IsExistNicknameRes(nickname, false);
         }
-        return new IsExistNicknameRes(nickname, false);
+
+        return new IsExistNicknameRes(nickname, true);
     }
 
     private void validateNickname(String userName, UserUpdateReq userUpdateReq) {
-        if (userUpdateReq.getNickName() != null && userRepository.existsByNickname(userUpdateReq.getNickName())) {
+
+        if (userUpdateReq.getNickName() != null && userRepository.existsNicknameExcludingSelf(userName, userUpdateReq.getNickName())) {
             log.warn("nickname is duplicate. user = {}, nickname = {}", userName, userUpdateReq.getNickName());
             throw new UserNicknameException(USER_NICKNAME_ERROR);
         }

--- a/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
@@ -18,6 +18,11 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -30,7 +35,9 @@ public class SecurityConfig {
     private final JWTTokenService tokenService;
     public static final String[] whiteList = {
             "/api/auth/login",
-            "/api/auth/check"
+            "/api/auth/check",
+            "/login/oauth2/code/**",
+            "/login/oauth2/authorization/**"
     };
 
     @Bean
@@ -44,6 +51,9 @@ public class SecurityConfig {
 
         http
                 .csrf(AbstractHttpConfigurer::disable);
+
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()));
 
         http
                 .formLogin(AbstractHttpConfigurer::disable);
@@ -85,18 +95,18 @@ public class SecurityConfig {
         return http.build();
     }
 
-//    @Bean
-//    public CorsConfigurationSource corsConfigurationSource() {
-//        CorsConfiguration configuration = new CorsConfiguration();
-//        configuration.setAllowedOriginPatterns(List.of("*"));
-//        configuration.setAllowedHeaders(List.of("*"));
-//        configuration.setAllowedMethods(List.of("*"));
-//        configuration.setAllowCredentials(true);
-//        configuration.setMaxAge(3600L);
-//
-//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-//        source.registerCorsConfiguration("/**", configuration);
-//        return source;
-//    }
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(List.of("*"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowedMethods(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
 
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepository.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByUsername(String username);
 
     Boolean existsByNickname(String nickname);

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
@@ -1,0 +1,6 @@
+package cafeLogProject.cafeLog.domains.user.repository;
+
+public interface UserRepositoryCustom {
+
+    boolean existsNicknameExcludingSelf(String username, String newNickname);
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
@@ -1,0 +1,22 @@
+package cafeLogProject.cafeLog.domains.user.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static cafeLogProject.cafeLog.domains.user.domain.QUser.user;
+
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public boolean existsNicknameExcludingSelf(String username, String newNickname) {
+
+        return queryFactory
+                .selectFrom(user)
+                .where(user.nickname.eq(newNickname)
+                        .and(user.username.ne(username)))
+                .fetchOne() != null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,7 +40,7 @@ spring:
             scope:
               - profile
               - email
-            redirect-uri: http://ec2-43-200-92-254.ap-northeast-2.compute.amazonaws.com:8080/login/oauth2/code/google
+            redirect-uri: https://ec2-43-200-92-254.ap-northeast-2.compute.amazonaws.com/login/oauth2/code/google
 
           facebook:
             client-id: ${FACEBOOK_CLIENT_ID}


### PR DESCRIPTION
## User 닉네임 중복체크 로직 수정
- 기존에 자신의 닉네임까지 중복체크 하는 로직 -> 자신의 닉네임을 제외하고 중복체크
  - queryDsl 을 사용하여 existsNicknameExcludingSelf() 구현

- 구글 리다이렉트 uri 를 http -> https 로 변경
- 구글 리다이렉트 uri 에 붙어있는 8080포트 제거