### PR TITLE
fix: Add server.tomcat.remoteip.portocol-header in application.yml

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
@@ -7,7 +7,6 @@ import cafeLogProject.cafeLog.common.auth.jwt.JWTLogoutFilter;
 import cafeLogProject.cafeLog.common.auth.jwt.JWTUtil;
 import cafeLogProject.cafeLog.common.auth.jwt.token.JWTTokenService;
 import cafeLogProject.cafeLog.common.auth.oauth2.CustomOAuth2UserService;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,11 @@ logging.level:
 path:
   base: ${PROJECT_PATH}
 
+server:
+  tomcat:
+    remoteip:
+      protocol-header: x-forwarded-proto
+
 front:
   redirect: ${FRONTEND_REDIRECT}
 


### PR DESCRIPTION
## Mixed Content 문제 해결
- https 페이지에서 http 리소스를 요청 하려는 경우 Mixed Content 발생
  - application.yml 설정에 server.tomcat.remoteip.portocol-header 추가
  - 참고 : https://velog.io/@jamie/mixed-content-error
