### PR TITLE
feat: Add User Search By Nickname

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package cafeLogProject.cafeLog.api.user.controller;
 
+import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
 import cafeLogProject.cafeLog.api.user.dto.IsExistNicknameRes;
 import cafeLogProject.cafeLog.api.user.dto.UserInfoRes;
 import cafeLogProject.cafeLog.api.user.dto.UserUpdateReq;
@@ -7,13 +8,18 @@ import cafeLogProject.cafeLog.api.user.service.UserService;
 import cafeLogProject.cafeLog.common.auth.oauth2.CustomOAuth2User;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
+@Slf4j
 public class UserController {
 
     private final UserService userService;
@@ -41,4 +47,10 @@ public class UserController {
         return ResponseEntity.ok(isExist);
     }
 
+    @GetMapping("/profile/search")
+    public ResponseEntity<List<UserSearchRes>> searchUsersByNickname(@RequestParam String name) {
+
+        List<UserSearchRes> userSearchRes = userService.searchUsersByNickname(name);
+        return ResponseEntity.ok(userSearchRes);
+    }
 }

--- a/src/main/java/cafeLogProject/cafeLog/api/user/dto/UserSearchRes.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/dto/UserSearchRes.java
@@ -1,0 +1,23 @@
+package cafeLogProject.cafeLog.api.user.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UserSearchRes {
+
+    private Long userId;
+    private String nickname;
+    private String introduce;
+
+    @QueryProjection
+    public UserSearchRes(Long userId, String nickname, String introduce) {
+
+        this.userId = userId;
+        this.nickname = nickname;
+        this.introduce = introduce;
+    }
+
+}

--- a/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
@@ -1,10 +1,12 @@
 package cafeLogProject.cafeLog.api.user.service;
 
+import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
 import cafeLogProject.cafeLog.api.user.dto.IsExistNicknameRes;
 import cafeLogProject.cafeLog.api.user.dto.UserInfoRes;
 import cafeLogProject.cafeLog.api.user.dto.UserUpdateReq;
 import cafeLogProject.cafeLog.common.auth.jwt.JWTUserDTO;
 import cafeLogProject.cafeLog.common.exception.user.UserNicknameException;
+import cafeLogProject.cafeLog.common.exception.user.UserNicknameNullException;
 import cafeLogProject.cafeLog.common.exception.user.UserNotFoundException;
 import cafeLogProject.cafeLog.domains.user.domain.User;
 import cafeLogProject.cafeLog.domains.user.repository.UserRepository;
@@ -13,8 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static cafeLogProject.cafeLog.common.exception.ErrorCode.USER_NICKNAME_ERROR;
-import static cafeLogProject.cafeLog.common.exception.ErrorCode.USER_NOT_FOUND_ERROR;
+import java.util.List;
+
+import static cafeLogProject.cafeLog.common.exception.ErrorCode.*;
 
 
 @Service
@@ -58,6 +61,15 @@ public class UserService {
         }
 
         return new IsExistNicknameRes(nickname, true);
+    }
+
+    public List<UserSearchRes> searchUsersByNickname(String nickname) {
+
+        if (nickname == null || nickname.trim().isEmpty()) {
+            throw new UserNicknameNullException(USER_NICKNAME_NULL_ERROR);
+        }
+
+        return userRepository.findByNicknameContainingIgnoreCase(nickname);
     }
 
     private void validateNickname(String userName, UserUpdateReq userUpdateReq) {

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/ErrorCode.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     USER_NOT_AUTH_ERROR(HttpStatus.UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     USER_NICKNAME_ERROR(HttpStatus.CONFLICT, "이미 사용중인 닉네임입니다"),
+    USER_NICKNAME_NULL_ERROR(HttpStatus.BAD_REQUEST, "검색하려는 닉네임이 비어있습니다."),
 
     TOKEN_EXPIRED_ERROR(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
     TOKEN_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "토큰을 찾지 못했습니다.."),

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/user/UserNicknameNullException.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/user/UserNicknameNullException.java
@@ -1,0 +1,14 @@
+package cafeLogProject.cafeLog.common.exception.user;
+
+import cafeLogProject.cafeLog.common.exception.CafeAppException;
+import cafeLogProject.cafeLog.common.exception.ErrorCode;
+
+public class UserNicknameNullException extends CafeAppException {
+    public UserNicknameNullException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public UserNicknameNullException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepository.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepository.java
@@ -3,11 +3,12 @@ package cafeLogProject.cafeLog.domains.user.repository;
 import cafeLogProject.cafeLog.domains.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByUsername(String username);
-
     Boolean existsByNickname(String nickname);
+
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
@@ -1,6 +1,12 @@
 package cafeLogProject.cafeLog.domains.user.repository;
 
+import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
+
+import java.util.List;
+
 public interface UserRepositoryCustom {
 
     boolean existsNicknameExcludingSelf(String username, String newNickname);
+    List<UserSearchRes> findByNicknameContainingIgnoreCase(String nickname);
+
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
@@ -1,7 +1,11 @@
 package cafeLogProject.cafeLog.domains.user.repository;
 
+import cafeLogProject.cafeLog.api.user.dto.QUserSearchRes;
+import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+
+import java.util.List;
 
 import static cafeLogProject.cafeLog.domains.user.domain.QUser.user;
 
@@ -18,5 +22,19 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
                 .where(user.nickname.eq(newNickname)
                         .and(user.username.ne(username)))
                 .fetchOne() != null;
+    }
+
+    @Override
+    public List<UserSearchRes> findByNicknameContainingIgnoreCase(String nickname) {
+
+        return queryFactory
+                .select(new QUserSearchRes(
+                        user.id,
+                        user.nickname,
+                        user.introduce
+                ))
+                .from(user)
+                .where(user.nickname.startsWith(nickname))
+                .fetch();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,7 @@ spring:
             scope:
               - profile
               - email
-            redirect-uri: https://brewscape-server.p-e.kr/login/oauth2/code/google
+#            redirect-uri: https://brewscape-server.p-e.kr/login/oauth2/code/google
 
           facebook:
             client-id: ${FACEBOOK_CLIENT_ID}


### PR DESCRIPTION
## 유저 닉네임으로 검색

- 검색하려는 닉네임으로 시작하는 유저를 리스트 반환(유저 아이디, 닉네임, 소개)
- QueryDsl 을 사용하여 해당 닉네임으로 시작하는 유저를 dto에 담아 리스트로 반환
- 없을 경우 빈 리스트
- 파라미터가 없거나 공백으로 이루어져 있을 경우 UserNicknameNullException 발생