### PR TITLE
feat: Add User Search By Nickname

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
@@ -1,8 +1,8 @@
 package cafeLogProject.cafeLog.api.user.controller;
 
-import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
 import cafeLogProject.cafeLog.api.user.dto.IsExistNicknameRes;
 import cafeLogProject.cafeLog.api.user.dto.UserInfoRes;
+import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
 import cafeLogProject.cafeLog.api.user.dto.UserUpdateReq;
 import cafeLogProject.cafeLog.api.user.service.UserService;
 import cafeLogProject.cafeLog.common.auth.oauth2.CustomOAuth2User;
@@ -14,7 +14,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequestMapping("/api")

--- a/src/main/java/cafeLogProject/cafeLog/api/user/dto/UserSearchRes.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/dto/UserSearchRes.java
@@ -12,6 +12,7 @@ public class UserSearchRes {
     private String nickname;
     private String introduce;
 
+
     @QueryProjection
     public UserSearchRes(Long userId, String nickname, String introduce) {
 

--- a/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
@@ -68,7 +68,6 @@ public class UserService {
         if (nickname == null || nickname.trim().isEmpty()) {
             throw new UserNicknameNullException(USER_NICKNAME_NULL_ERROR);
         }
-
         return userRepository.findByNicknameContainingIgnoreCase(nickname);
     }
 

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
@@ -37,4 +37,5 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
                 .where(user.nickname.startsWith(nickname))
                 .fetch();
     }
+
 }


### PR DESCRIPTION
## 유저 닉네임으로 검색

- 검색하려는 닉네임으로 시작하는 유저를 리스트 반환(유저 아이디, 닉네임, 소개)
- QueryDsl 을 사용하여 해당 닉네임으로 시작하는 유저를 dto에 담아 리스트로 반환
- 없을 경우 빈 리스트
- 파라미터가 없거나 공백으로 이루어져 있을 경우 UserNicknameNullException 발생