### PR TITLE
feat: Follow API 추가

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/api/follow/controller/FollowController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/follow/controller/FollowController.java
@@ -1,0 +1,57 @@
+package cafeLogProject.cafeLog.api.follow.controller;
+
+import cafeLogProject.cafeLog.api.follow.dto.FollowRes;
+import cafeLogProject.cafeLog.api.follow.dto.UserFollowRes;
+import cafeLogProject.cafeLog.api.follow.service.FollowService;
+import cafeLogProject.cafeLog.common.auth.oauth2.CustomOAuth2User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class FollowController {
+
+    private final FollowService followService;
+
+    @PostMapping("/follow/{userId}")
+    public ResponseEntity<FollowRes> followUser(@AuthenticationPrincipal CustomOAuth2User user,
+                                                @PathVariable Long userId) {
+
+        FollowRes followRes = followService.followUser(user.getName(), userId);
+        return ResponseEntity.ok(followRes);
+    }
+
+    @DeleteMapping("/follow/{userId}")
+    public ResponseEntity<FollowRes> unfollowUser(@AuthenticationPrincipal CustomOAuth2User user,
+                                                @PathVariable Long userId) {
+
+        FollowRes followRes = followService.unfollowUser(user.getName(), userId);
+        return ResponseEntity.ok(followRes);
+    }
+
+    @GetMapping("/users/{userId}/follower")
+    public ResponseEntity<List<UserFollowRes>> getFollowerList(@AuthenticationPrincipal CustomOAuth2User user,
+                                                               @PathVariable Long userId,
+                                                               @RequestParam(defaultValue = "10") int limit,
+                                                               @RequestParam(required = false) Long cursor
+                                                               ) {
+
+        List<UserFollowRes> followerList = followService.getFollowerList(user.getName(), userId, limit, cursor);
+        return ResponseEntity.ok(followerList);
+    }
+
+    @GetMapping("/users/{userId}/following")
+    public ResponseEntity<List<UserFollowRes>> getFollowingList(@AuthenticationPrincipal CustomOAuth2User user,
+                                                                @PathVariable Long userId,
+                                                                @RequestParam(defaultValue = "10") int limit,
+                                                                @RequestParam(required = false) Long cursor) {
+
+        List<UserFollowRes> followingList = followService.getFollowingList(user.getName(), userId, limit, cursor);
+        return ResponseEntity.ok(followingList);
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/api/follow/dto/FollowRes.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/follow/dto/FollowRes.java
@@ -1,0 +1,11 @@
+package cafeLogProject.cafeLog.api.follow.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class FollowRes {
+
+    private String message;
+}

--- a/src/main/java/cafeLogProject/cafeLog/api/follow/dto/UserFollowRes.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/follow/dto/UserFollowRes.java
@@ -1,0 +1,36 @@
+package cafeLogProject.cafeLog.api.follow.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Data;
+
+
+@Data
+public class UserFollowRes {
+
+    private Long userId;
+
+    private String nickname;
+
+    private Boolean isProfileImageExist;
+
+    private int follower_cnt;
+
+    private int review_cnt;
+
+    @JsonProperty("isFollow")
+    private int isFollow;
+
+    private Long followId;
+
+    @QueryProjection
+    public UserFollowRes(Long userId, String nickname, Boolean isProfileImageExist, int follower_cnt, int review_cnt, Long followId) {
+
+        this.userId = userId;
+        this.nickname = nickname;
+        this.isProfileImageExist = isProfileImageExist;
+        this.follower_cnt = follower_cnt;
+        this.review_cnt = review_cnt;
+        this.followId = followId;
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/api/follow/service/FollowService.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/follow/service/FollowService.java
@@ -1,0 +1,121 @@
+package cafeLogProject.cafeLog.api.follow.service;
+
+import cafeLogProject.cafeLog.api.follow.dto.FollowRes;
+import cafeLogProject.cafeLog.api.follow.dto.UserFollowRes;
+import cafeLogProject.cafeLog.common.exception.follow.FollowSelfException;
+import cafeLogProject.cafeLog.common.exception.follow.FollowUserNotFoundException;
+import cafeLogProject.cafeLog.common.exception.user.UserNotFoundException;
+import cafeLogProject.cafeLog.domains.follow.domain.Follow;
+import cafeLogProject.cafeLog.domains.follow.repository.FollowRepository;
+import cafeLogProject.cafeLog.domains.user.domain.User;
+import cafeLogProject.cafeLog.domains.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static cafeLogProject.cafeLog.common.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class FollowService {
+
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public FollowRes followUser(String username, Long otherUserId) {
+
+        User currentUser = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+        User otherUser = userRepository.findById(otherUserId)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+
+        if (!canFollow(currentUser, otherUser)) {
+            return new FollowRes("이미 팔로우한 사용자입니다.");
+        }
+
+        addFollowAndPlusCount(currentUser, otherUser);
+        return new FollowRes("사용자를 팔로우했습니다.");
+    }
+
+    @Transactional
+    public FollowRes unfollowUser(String username, Long otherUserId) {
+
+        User currentUser = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+        User otherUser = userRepository.findById(otherUserId)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+
+        if (!canUnfollow(currentUser, otherUser)) {
+            return new FollowRes("이미 팔로우하지 않은 사용자입니다.");
+        }
+
+        deleteFollowAndMinusCount(currentUser, otherUser);
+        return new FollowRes("사용자를 언팔로우했습니다.");
+    }
+
+    public List<UserFollowRes> getFollowerList(String username, Long otherUserId, int limit, Long cursor) {
+
+        User user = validateUser(username, otherUserId);
+
+        return followRepository.getFollowerList(user.getId(), otherUserId, limit, cursor);
+    }
+
+    public List<UserFollowRes> getFollowingList(String username, Long otherUserId, int limit, Long cursor) {
+
+        User user = validateUser(username, otherUserId);
+
+        return followRepository.getFollowingList(user.getId(), otherUserId, limit, cursor);
+    }
+
+    private User validateUser(String username, Long otherUserId) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+
+        boolean isExistUser = userRepository.existsById(otherUserId);
+        if (!isExistUser) {
+            throw new FollowUserNotFoundException(FOLLOW_USER_NOT_FOUND_ERROR);
+        }
+        return user;
+    }
+
+    private boolean canFollow(User currentUser, User otherUser) {
+
+        if (currentUser.equals(otherUser)) {
+            throw new FollowSelfException(FOLLOW_SELF_ERROR);
+        }
+
+        return !followRepository.existsByFollowerAndFollowing(currentUser, otherUser);
+    }
+
+    private void addFollowAndPlusCount(User currentUser, User otherUser) {
+
+        Follow follow = Follow.builder()
+                .follower(currentUser)
+                .following(otherUser)
+                .build();
+
+        followRepository.save(follow);
+        currentUser.plusFollowingCnt();
+        otherUser.plusFollowerCnt();
+        log.info("{} 님을 팔로우했습니다.", otherUser.getNickname());
+    }
+
+    private boolean canUnfollow(User currentUser, User otherUser) {
+
+        return followRepository.existsByFollowerAndFollowing(currentUser, otherUser);
+    }
+
+    private void deleteFollowAndMinusCount(User currentUser, User otherUser) {
+
+        followRepository.deleteFollow(currentUser, otherUser);
+        currentUser.minusFollowingCnt();
+        otherUser.minusFollowerCnt();
+        log.info("{} 님을 언팔로우했습니다.", otherUser.getNickname());
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
@@ -1,9 +1,6 @@
 package cafeLogProject.cafeLog.api.user.controller;
 
-import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
-import cafeLogProject.cafeLog.api.user.dto.IsExistNicknameRes;
-import cafeLogProject.cafeLog.api.user.dto.UserInfoRes;
-import cafeLogProject.cafeLog.api.user.dto.UserUpdateReq;
+import cafeLogProject.cafeLog.api.user.dto.*;
 import cafeLogProject.cafeLog.api.user.service.UserService;
 import cafeLogProject.cafeLog.common.auth.oauth2.CustomOAuth2User;
 import jakarta.validation.Valid;
@@ -52,5 +49,13 @@ public class UserController {
 
         List<UserSearchRes> userSearchRes = userService.searchUsersByNickname(name);
         return ResponseEntity.ok(userSearchRes);
+    }
+
+    @GetMapping("/users/{userId}")
+    public ResponseEntity<OtherUserInfoRes> getOtherUserInfo(@AuthenticationPrincipal CustomOAuth2User user,
+                                                             @PathVariable Long userId) {
+
+        OtherUserInfoRes otherUserInfo = userService.getOtherUserInfo(user.getName(), userId);
+        return ResponseEntity.ok(otherUserInfo);
     }
 }

--- a/src/main/java/cafeLogProject/cafeLog/api/user/dto/OtherUserInfoRes.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/dto/OtherUserInfoRes.java
@@ -1,13 +1,11 @@
 package cafeLogProject.cafeLog.api.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.Builder;
 import lombok.Data;
 
-import java.util.LinkedList;
-
 @Data
-public class UserInfoRes {
+public class OtherUserInfoRes {
 
     private Long userId;
 
@@ -19,6 +17,9 @@ public class UserInfoRes {
 
     private Boolean isProfileImageExist;
 
+    @JsonProperty("isFollow")
+    private boolean isFollow;
+
     private int follower_cnt;
 
     private int following_cnt;
@@ -26,12 +27,14 @@ public class UserInfoRes {
     private int review_cnt;
 
     @QueryProjection
-    public UserInfoRes(Long userId, String nickname, String introduce, String email, Boolean isProfileImageExist, int follower_cnt, int following_cnt, int review_cnt) {
+    public OtherUserInfoRes(Long userId, String nickname, String introduce, String email, Boolean isProfileImageExist, boolean isFollow, int follower_cnt, int following_cnt, int review_cnt) {
+
         this.userId = userId;
         this.nickname = nickname;
         this.introduce = introduce;
         this.email = email;
         this.isProfileImageExist = isProfileImageExist;
+        this.isFollow = isFollow;
         this.follower_cnt = follower_cnt;
         this.following_cnt = following_cnt;
         this.review_cnt = review_cnt;

--- a/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
@@ -53,7 +53,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable);
 
         http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()));
+                .cors(AbstractHttpConfigurer::disable);
 
         http
                 .formLogin(AbstractHttpConfigurer::disable);
@@ -95,18 +95,5 @@ public class SecurityConfig {
         return http.build();
     }
 
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of("https://packetbreeze.com"));
-        configuration.setAllowedHeaders(List.of("*"));
-        configuration.setAllowedMethods(List.of("*"));
-        configuration.setAllowCredentials(true);
-        configuration.setMaxAge(3600L);
-
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", configuration);
-        return source;
-    }
 
 }

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/ErrorCode.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/ErrorCode.java
@@ -43,7 +43,10 @@ public enum ErrorCode {
     IMAGE_LOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류에 의해 이미지를 불러오지 못했습니다."),
     IMAGE_INVALID_ERROR(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "이미지 파일 형식이 아닙니다."),
     IMAGE_DAMAGED_ERROR(HttpStatus.BAD_REQUEST, "손상된 이미지 파일입니다."),
-    IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류에 의해 이미지를 삭제하지 못했습니다.");
+    IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류에 의해 이미지를 삭제하지 못했습니다."),
+
+    FOLLOW_SELF_ERROR(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우 할 수 없습니다."),
+    FOLLOW_USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/follow/FollowSelfException.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/follow/FollowSelfException.java
@@ -1,0 +1,14 @@
+package cafeLogProject.cafeLog.common.exception.follow;
+
+import cafeLogProject.cafeLog.common.exception.CafeAppException;
+import cafeLogProject.cafeLog.common.exception.ErrorCode;
+
+public class FollowSelfException extends CafeAppException {
+    public FollowSelfException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public FollowSelfException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/follow/FollowUserNotFoundException.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/follow/FollowUserNotFoundException.java
@@ -1,0 +1,14 @@
+package cafeLogProject.cafeLog.common.exception.follow;
+
+import cafeLogProject.cafeLog.common.exception.CafeAppException;
+import cafeLogProject.cafeLog.common.exception.ErrorCode;
+
+public class FollowUserNotFoundException extends CafeAppException {
+    public FollowUserNotFoundException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public FollowUserNotFoundException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/follow/domain/Follow.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/follow/domain/Follow.java
@@ -1,0 +1,35 @@
+package cafeLogProject.cafeLog.domains.follow.domain;
+
+import cafeLogProject.cafeLog.domains.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "follow_tb")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "follower_id")
+    private User follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "following_id")
+    private User following;
+
+    @Builder
+    public Follow(User follower, User following) {
+        this.follower = follower;
+        this.following = following;
+    }
+
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepository.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepository.java
@@ -1,0 +1,10 @@
+package cafeLogProject.cafeLog.domains.follow.repository;
+
+import cafeLogProject.cafeLog.domains.follow.domain.Follow;
+import cafeLogProject.cafeLog.domains.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {
+
+    boolean existsByFollowerAndFollowing(User follower, User following);
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepositoryCustom.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepositoryCustom.java
@@ -1,0 +1,13 @@
+package cafeLogProject.cafeLog.domains.follow.repository;
+
+import cafeLogProject.cafeLog.api.follow.dto.UserFollowRes;
+import cafeLogProject.cafeLog.domains.user.domain.User;
+
+import java.util.List;
+
+public interface FollowRepositoryCustom {
+
+    void deleteFollow(User currentUser, User otherUser);
+    List<UserFollowRes> getFollowerList(Long currentUserId, Long otherUserId, int limit, Long cursor);
+    List<UserFollowRes> getFollowingList(Long currentUserId, Long otherUserId, int limit, Long cursor);
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepositoryImpl.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepositoryImpl.java
@@ -1,0 +1,224 @@
+package cafeLogProject.cafeLog.domains.follow.repository;
+
+import cafeLogProject.cafeLog.api.follow.dto.QUserFollowRes;
+import cafeLogProject.cafeLog.api.follow.dto.UserFollowRes;
+import cafeLogProject.cafeLog.domains.user.domain.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import static cafeLogProject.cafeLog.domains.follow.domain.QFollow.follow;
+import static cafeLogProject.cafeLog.domains.review.domain.QReview.review;
+import static cafeLogProject.cafeLog.domains.user.domain.QUser.user;
+
+
+@RequiredArgsConstructor
+public class FollowRepositoryImpl implements FollowRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public void deleteFollow(User currentUser, User otherUser) {
+
+        queryFactory.delete(follow)
+                .where(follow.follower.id.eq(currentUser.getId())
+                        .and(follow.following.id.eq(otherUser.getId())))
+                .execute();
+    }
+
+    @Override
+    public List<UserFollowRes> getFollowerList(Long currentUserId, Long otherUserId, int limit, Long cursor) {
+        return getFollowList(currentUserId, otherUserId, limit, cursor, true);
+    }
+
+    @Override
+    public List<UserFollowRes> getFollowingList(Long currentUserId, Long otherUserId, int limit, Long cursor) {
+        return getFollowList(currentUserId, otherUserId, limit, cursor, false);
+    }
+
+    /**
+     *
+     * @param currentUserId 현재 로그인한 사용자
+     * @param otherUserId 해당 아이디를 가진 사용자의 팔로우,팔로잉 리스트 조회
+     * @param isFollower [true -> 팔로워 리스트], [false -> 팔로잉 리스트]
+     *
+     * @method getMyFollowingList() -> 내가 팔로잉하고 있는 유저들 리스트로 반환
+     * @method setIsFollow() -> 해당 아이디를 가진 사용자의 팔로우,팔로잉 리스트에 나오는 유저들
+     *                          1) 리스트 안에 있는 유저가 나 자신일 경우(우선순위1) -> isFollow = 2
+     *                               - front 에서 팔로우,언팔로우 버튼 x (구분을 위해 2로 설정)
+     *                          2) 리스트 안에 있는 유저를 내가 팔로잉 하고 있을 경우(우선순위2) -> isFollow = 1
+     *                          3) 리스트 안에 있는 유저를 내가 팔로잉 하고 있지 않을 경우(우선순위3) -> isFollow = 0
+     *                          *) isFollow 값이 같은 경우에는 팔로우 아이디로 역순(최신순)
+     *
+     * return 우선순위에 따라 커서 기반 페이지네이션
+     */
+    private List<UserFollowRes> getFollowList(Long currentUserId, Long otherUserId, int limit, Long cursor, boolean isFollower) {
+
+        List<UserFollowRes> followList = queryFactory
+                .select(new QUserFollowRes(
+                        user.id,
+                        user.nickname,
+                        user.isImageExist,
+                        user.followerCnt,
+                        review.count().intValue(),
+                        follow.id
+                ))
+                .from(follow)
+                .leftJoin(user).on(isFollower ? user.id.eq(follow.follower.id) : user.id.eq(follow.following.id))
+                .leftJoin(review).on(review.user.eq(user))
+                .where(isFollower ? follow.following.id.eq(otherUserId) : follow.follower.id.eq(otherUserId))
+                .groupBy(user.id, follow.id)
+                .fetch();
+
+        List<Long> myFollowingList = getMyFollowingList(currentUserId);
+        setIsFollow(currentUserId, followList, myFollowingList);
+
+        return paginateFollowList(limit, cursor, followList, currentUserId, otherUserId);
+    }
+
+    private List<Long> getMyFollowingList(Long currentUserId) {
+
+        List<Long> followedUserIds = queryFactory
+                .select(follow.following.id)
+                .from(follow)
+                .where(follow.follower.id.eq(currentUserId))
+                .fetch();
+
+        return followedUserIds;
+    }
+
+    private void setIsFollow(Long currentUserId, List<UserFollowRes> followList, List<Long> myFollowingList) {
+
+        for (UserFollowRes follower : followList) {
+            if (follower.getUserId() == currentUserId) {
+                follower.setIsFollow(2);
+            } else if (myFollowingList.contains(follower.getUserId())) {
+                follower.setIsFollow(1);
+            } else {
+                follower.setIsFollow(0);
+            }
+        }
+    }
+
+    private List<UserFollowRes> paginateFollowList(int limit, Long cursor, List<UserFollowRes> followList, Long currentUserId, Long otherUserId) {
+
+        List<UserFollowRes> result = new ArrayList<>();
+
+        if (cursor == null) {
+            result.addAll(getSortedFollowList(limit, followList));
+        } else {
+            boolean amIFollowingCursorUser = amIFollowing(currentUserId, cursor);
+            if (amIFollowingCursorUser) {
+                addFollowingUsers(result, followList, cursor, limit, currentUserId, otherUserId);
+            } else {
+                addUnfollowingUsers(result, followList, cursor, limit);
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * cursor == null -> 정렬후에 limit 만큼 조회 결과 반환
+     */
+    private List<UserFollowRes> getSortedFollowList(int limit, List<UserFollowRes> followList) {
+        Collections.sort(followList, (user1, user2) -> {
+            if (user1.getIsFollow() < user2.getIsFollow()) return 1;
+            else if (user1.getIsFollow() > user2.getIsFollow()) return -1;
+            else return Long.compare(user2.getFollowId(), user1.getFollowId());
+        });
+
+        List<UserFollowRes> list = followList.stream()
+                .limit(limit)
+                .toList();
+        return list;
+    }
+
+    /**
+     * @return cursor 의 값을 follow.id 로 가진 유저를 내가 팔로잉했는지 boolean 값으로 반환
+     *          * true 일 경우 -> 내가 팔로잉하고 있는 유저부터 조회하기 위해.
+     *          * false 일 경우 -> 내가 팔로잉하고 있지 않은 유저만 조회하기 위해.
+     */
+    private boolean amIFollowing(Long currentUserId, Long cursor) {
+
+            return queryFactory
+                    .select(follow.id)
+                    .from(follow)
+                    .where(follow.follower.id.eq(currentUserId)
+                            .and(follow.following.id.eq(cursor)))
+                    .fetchOne() != null;
+    }
+
+    /**
+     *  내가 팔로잉하고 있는 유저 커서 기반 우선 조회. isFollow = 1 인 유저.
+     *  반환 조회 결과가 limit 보다 작다면 cursor 의 값을 임의로 내가 팔로잉하고 있지 않은 유저 중에서 제일 큰 follow.id 값 + 1로 설정.
+     *                  -> Ex) isFollow = 1 인 유저들 중에 내가 마지막으로 조회한 유저의 follow.id 가 1 일 경우.
+     *                         -> isFollow = 0 인 유저들이 조회 안됨 -> 1보다 작은 follow.id 는 없기 때문.
+     *                         => 따라서 isFollow = 0 인 유저들을 조회하기 위해 isFollow = 0 인 유저의 follow.id 최댓값 + 1 으로 설정
+     *                              -> follow.id 최댓값에 + 1 을 안할 경우에 follow.id 최댓값을 가진 유저가 조회 안되기 때문
+     *
+     * @method getMaxFollowIdWithIsUnfollowing() -> return (isFollow = 0 인 유저의 follow.id 최댓값 + 1)
+     * @method addUnfollowingUsersUpToMaxFollowId -> isFollow = 0 인 유저를 최신순으로 조회
+     */
+    private void addFollowingUsers(List<UserFollowRes> result, List<UserFollowRes> followList, Long cursor, int limit, Long currentUserId, Long otherUserId) {
+        List<UserFollowRes> followingList = followList.stream()
+                .filter(follower -> follower.getIsFollow() == 1 && follower.getFollowId() < cursor)
+                .sorted(Comparator.comparingLong(UserFollowRes::getFollowId).reversed())
+                .limit(limit)
+                .toList();
+
+        result.addAll(followingList);
+
+        if (result.size() < limit) {
+            Long maxFollowId = getMaxFollowIdWithIsUnfollowing(currentUserId, otherUserId);
+            addUnfollowingUsersUpToMaxFollowId(result, followList, maxFollowId, limit - result.size());
+        }
+    }
+
+
+    private Long getMaxFollowIdWithIsUnfollowing(Long currentUserId, Long otherUserId) {
+
+        Long maxFollowIdWithIsUnfollowing = queryFactory
+                .select(follow.id.max())
+                .from(follow)
+                .where(follow.follower.id.ne(currentUserId)
+                        .and(follow.following.id.eq(otherUserId)))
+                .fetchOne();
+
+        if (maxFollowIdWithIsUnfollowing != null) {
+            maxFollowIdWithIsUnfollowing += 1;
+        }
+
+        return maxFollowIdWithIsUnfollowing;
+    }
+
+    private void addUnfollowingUsersUpToMaxFollowId(List<UserFollowRes> result, List<UserFollowRes> followList, Long maxFollowId, int remain) {
+        List<UserFollowRes> remainingList = followList.stream()
+                .filter(follower -> follower.getIsFollow() == 0 && follower.getFollowId() < maxFollowId)
+                .sorted(Comparator.comparingLong(UserFollowRes::getFollowId).reversed())
+                .limit(remain)
+                .toList();
+
+        result.addAll(remainingList);
+    }
+
+    /**
+     * 내가 팔로잉 하지 않은 유저들 -> isFollow=0 인 유저들을 커서 기반 조회
+     */
+    private void addUnfollowingUsers(List<UserFollowRes> result, List<UserFollowRes> followList, Long cursor, int limit) {
+        List<UserFollowRes> unfollowingList = followList.stream()
+                .filter(follower -> follower.getIsFollow() == 0 && follower.getFollowId() < cursor)
+                .sorted(Comparator.comparingLong(UserFollowRes::getFollowId).reversed())
+                .limit(limit)
+                .toList();
+
+        result.addAll(unfollowingList);
+    }
+
+
+
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/review/repository/ReviewRepository.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/review/repository/ReviewRepository.java
@@ -1,8 +1,11 @@
 package cafeLogProject.cafeLog.domains.review.repository;
 
 import cafeLogProject.cafeLog.domains.review.domain.Review;
+import cafeLogProject.cafeLog.domains.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewRepositoryCustom {
+
+    int countByUser(User user);
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/domain/User.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/domain/User.java
@@ -39,6 +39,10 @@ public class User extends BaseEntity {
 
     private String provider;
 
+    private int followerCnt = 0;
+
+    private int followingCnt= 0;
+
     @Enumerated(EnumType.STRING)
     private UserRole role = ROLE_USER;
 
@@ -69,5 +73,25 @@ public class User extends BaseEntity {
     public void setNicknameFirstLogin(String randomNickname) {
 
         this.nickname = randomNickname;
+    }
+
+    public void plusFollowerCnt() {
+        this.followerCnt += 1;
+    }
+
+    public void minusFollowerCnt() {
+        if (this.followerCnt > 0) {
+            this.followerCnt -= 1;
+        }
+    }
+
+    public void plusFollowingCnt() {
+        this.followingCnt += 1;
+    }
+
+    public void minusFollowingCnt() {
+        if (this.followingCnt > 0) {
+            this.followingCnt -= 1;
+        }
     }
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
@@ -1,12 +1,16 @@
 package cafeLogProject.cafeLog.domains.user.repository;
 
+import cafeLogProject.cafeLog.api.user.dto.OtherUserInfoRes;
+import cafeLogProject.cafeLog.api.user.dto.UserInfoRes;
 import cafeLogProject.cafeLog.api.user.dto.UserSearchRes;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface UserRepositoryCustom {
 
     boolean existsNicknameExcludingSelf(String username, String newNickname);
     List<UserSearchRes> findByNicknameContainingIgnoreCase(String nickname);
-
+    Optional<OtherUserInfoRes> findOtherUserInfo(String currentUsername, Long otherUserId);
+    Optional<UserInfoRes> findMyProfileWithReviewCount(String username);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,7 @@ spring:
             scope:
               - profile
               - email
-#            redirect-uri: https://brewscape-server.p-e.kr/login/oauth2/code/google
+            redirect-uri: ${GOOGLE_REDIRECT_URI}
 
           facebook:
             client-id: ${FACEBOOK_CLIENT_ID}
@@ -74,6 +74,7 @@ path:
   base: ${PROJECT_PATH}
 
 server:
+  port: ${SERVER_PORT:8080}
   tomcat:
     remoteip:
       protocol-header: x-forwarded-proto


### PR DESCRIPTION
## 변경 사항

- Follow API 추가
- 사용자 프로필 조회 시 응답 값에 리뷰 작성 수, 팔로워 수, 팔로잉 수 추가
- application.yml 에 server.port 추가. google-redirect-uri 환경변수로 관리

### Follow API 추가

- 팔로잉 하기
- 언팔로우 하기
- 팔로워,팔로잉 리스트 조회(커서 기반 페이지네이션)
   - 우선순위 1) 내가 리스트 목록에 있는 경우 -> isFollow = 2
   - 우선순위 2) 내가 팔로잉하는 유저일 경우 -> isFollow = 1
   - 우선순위 3) 내가 팔로잉하지 않는 유저일 경우 -> isFollow = 0
   - 우선순위가 같을 경우 -> follow 아이디 역순(최신순)
   
