### PR TITLE
fix: Implemented Redis caching for follow status

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/common/config/RedisConfig.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/config/RedisConfig.java
@@ -12,6 +12,8 @@ import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 
+import java.util.List;
+
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig {

--- a/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/config/SecurityConfig.java
@@ -17,11 +17,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.authentication.logout.LogoutFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/ErrorCode.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/ErrorCode.java
@@ -46,7 +46,8 @@ public enum ErrorCode {
     IMAGE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 오류에 의해 이미지를 삭제하지 못했습니다."),
 
     FOLLOW_SELF_ERROR(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우 할 수 없습니다."),
-    FOLLOW_USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다.");
+    FOLLOW_USER_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "해당 유저를 찾을 수 없습니다."),
+    FOLLOW_CURSOR_EXCEPTION(HttpStatus.BAD_REQUEST, "유효하지 않은 커서입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/cafeLogProject/cafeLog/common/exception/FollowCursorException.java
+++ b/src/main/java/cafeLogProject/cafeLog/common/exception/FollowCursorException.java
@@ -1,0 +1,11 @@
+package cafeLogProject.cafeLog.common.exception;
+
+public class FollowCursorException extends CafeAppException{
+    public FollowCursorException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public FollowCursorException(String message, ErrorCode errorCode) {
+        super(message, errorCode);
+    }
+}

--- a/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepository.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepository.java
@@ -4,7 +4,10 @@ import cafeLogProject.cafeLog.domains.follow.domain.Follow;
 import cafeLogProject.cafeLog.domains.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FollowRepository extends JpaRepository<Follow, Long>, FollowRepositoryCustom {
 
     boolean existsByFollowerAndFollowing(User follower, User following);
+
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepositoryCustom.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/follow/repository/FollowRepositoryCustom.java
@@ -10,4 +10,5 @@ public interface FollowRepositoryCustom {
     void deleteFollow(User currentUser, User otherUser);
     List<UserFollowRes> getFollowerList(Long currentUserId, Long otherUserId, int limit, Long cursor);
     List<UserFollowRes> getFollowingList(Long currentUserId, Long otherUserId, int limit, Long cursor);
+
 }


### PR DESCRIPTION
## 변경사항

### 마지막으로 조회한 팔로우아이디를 가진 팔로우가 삭제되었을때 문제 해결

- 조회할 때마다 마지막 결과를 Redis에 캐싱 (키: 현재 유저 ID: 조회하려는 유저 ID, 값: 마지막으로 조회한 followId:isFollow).
  - 마지막으로 조회한 팔로우아이디가 삭제되어도 정상적으로 조회할 수 있도록 함. 
  - db에는 값이 없어도 레디스에는 있기 때문.
- 커서 설정 시 Redis에 저장한 값의 followId가 일치하는지 확인.
- 설정한 커서와 Redis에 저장된 followId가 다르면 예외 발생.
- 마지막으로 조회한 팔로우 ID를 커서로 사용했을 때만 유효.
- followId 가 일치하다면 isFollow 가 0인지 1인지 확인하여 다음 조회결과 반환
- TTL을 1시간으로 설정하여 1시간 후에는 Redis에서 해당 키를 가진 데이터 삭제.
