### PR TITLE
feat: 팔로우한 사용자의 리뷰들을 조회하는 API

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/api/review/controller/ReviewController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/review/controller/ReviewController.java
@@ -19,40 +19,40 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @GetMapping("/{reviewId}")
-    public ResponseEntity<ShowReviewResponse> findReviewByReviewId(@PathVariable(value="reviewId") Long reviewId) {
+    public ResponseEntity<ShowReviewResponse> findReviewByReviewId(@PathVariable(value = "reviewId") Long reviewId) {
         ShowReviewResponse showReviewResponse = reviewService.findReview(reviewId);
         return ResponseEntity.ok().body(showReviewResponse);
     }
 
     @GetMapping("/cafe/{cafeId}")
-    public ResponseEntity<List<ShowReviewResponse>> showCafeReviews(@PathVariable(value="cafeId") Long cafeId,
+    public ResponseEntity<List<ShowReviewResponse>> showCafeReviews(@PathVariable(value = "cafeId") Long cafeId,
                                                                     @ModelAttribute @Valid ShowCafeReviewRequest showCafeReviewRequest) {
         List<ShowReviewResponse> res = reviewService.findCafeReviews(cafeId, showCafeReviewRequest);
         return ResponseEntity.ok().body(res);
     }
 
     @GetMapping("/list")
-    public ResponseEntity<List<ShowReviewResponse>> showReviews(@ModelAttribute @Valid ShowReviewRequest showReviewRequest){
+    public ResponseEntity<List<ShowReviewResponse>> showReviews(@ModelAttribute @Valid ShowReviewRequest showReviewRequest) {
         List<ShowReviewResponse> res = reviewService.findReviews(showReviewRequest);
         return ResponseEntity.ok().body(res);
     }
 
     @GetMapping("/my")
     public ResponseEntity<List<ShowReviewResponse>> showMyReviews(@AuthenticationPrincipal CustomOAuth2User oAuth2User,
-                                                                  @ModelAttribute @Valid ShowUserReviewRequest showUserReviewRequest){
+                                                                  @ModelAttribute @Valid ShowUserReviewRequest showUserReviewRequest) {
         List<ShowReviewResponse> review = reviewService.findUserReviews(oAuth2User.getName(), showUserReviewRequest);
         return ResponseEntity.ok().body(review);
     }
 
     @GetMapping("/user")
     public ResponseEntity<List<ShowReviewResponse>> showReviewsByUserId(@NotNull(message = "userId는 필수입니다") Long userId,
-                                                                  @ModelAttribute @Valid ShowUserReviewRequest showUserReviewRequest){
+                                                                        @ModelAttribute @Valid ShowUserReviewRequest showUserReviewRequest) {
         List<ShowReviewResponse> review = reviewService.findUserReviews(userId, showUserReviewRequest);
         return ResponseEntity.ok().body(review);
     }
 
     @PostMapping("{draftReviewId}")
-    public ResponseEntity<ShowReviewResponse> registReview(@PathVariable(value="draftReviewId") Long draftReviewId,
+    public ResponseEntity<ShowReviewResponse> registReview(@PathVariable(value = "draftReviewId") Long draftReviewId,
                                                            @RequestBody @Valid RegistReviewRequest registReviewRequest,
                                                            @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
         ShowReviewResponse res = reviewService.addReview(oAuth2User.getName(), draftReviewId, registReviewRequest);
@@ -60,7 +60,7 @@ public class ReviewController {
     }
 
     @PatchMapping("/{reviewId}")
-    public ResponseEntity<ShowReviewResponse> updateReview(@PathVariable(value="reviewId") Long reviewId,
+    public ResponseEntity<ShowReviewResponse> updateReview(@PathVariable(value = "reviewId") Long reviewId,
                                                            @RequestBody @Valid UpdateReviewRequest updateReviewRequest,
                                                            @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
         ShowReviewResponse res = reviewService.updateReview(oAuth2User.getName(), reviewId, updateReviewRequest);
@@ -68,9 +68,26 @@ public class ReviewController {
     }
 
     @DeleteMapping("/{reviewId}")
-    public ResponseEntity<?> deleteReview(@PathVariable(value="reviewId") Long reviewId,
+    public ResponseEntity<?> deleteReview(@PathVariable(value = "reviewId") Long reviewId,
                                           @AuthenticationPrincipal CustomOAuth2User oAuth2User) {
         reviewService.deleteReview(oAuth2User.getName(), reviewId);
         return ResponseEntity.ok().body(null);
+    }
+
+    @GetMapping("/follow")
+    public ResponseEntity<List<ShowReviewResponse>> getFollowingUsersReviews(
+            @AuthenticationPrincipal CustomOAuth2User user,
+            @ModelAttribute @Valid ShowUserReviewRequest request) {
+
+        List<ShowReviewResponse> reviews = reviewService.findFollowingUsersReviews(
+                user.getName(),
+                request
+        );
+
+        if (reviews.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(reviews);
     }
 }

--- a/src/main/java/cafeLogProject/cafeLog/api/review/controller/ReviewController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/review/controller/ReviewController.java
@@ -84,10 +84,6 @@ public class ReviewController {
                 request
         );
 
-        if (reviews.isEmpty()) {
-            return ResponseEntity.noContent().build();
-        }
-
         return ResponseEntity.ok(reviews);
     }
 }

--- a/src/main/java/cafeLogProject/cafeLog/api/review/service/ReviewService.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/review/service/ReviewService.java
@@ -208,5 +208,11 @@ public class ReviewService {
     }
 
 
+    public List<ShowReviewResponse> findFollowingUsersReviews(String username, ShowUserReviewRequest request) {
+        User currentUser = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UserNotFoundException(username, ErrorCode.USER_NOT_FOUND_ERROR));
 
+        Pageable pageable = PageRequest.of(0, request.getLimit());
+        return reviewRepository.searchByFollowingUsers(currentUser.getId(), request.getTimestamp(), pageable);
+    }
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/review/repository/ReviewRepositoryCustom.java
@@ -23,4 +23,6 @@ public interface ReviewRepositoryCustom {
     // 모든 리뷰 조회 & 필터링
     // 특정 매개변수가 null인 경우 조건 건너뜀
     List<ShowReviewResponse> search(String orderMethod, List<Integer> tagIds, Integer currentRating, LocalDateTime createdAt, Pageable pageable);
+
+    List<ShowReviewResponse> searchByFollowingUsers(Long id, LocalDateTime timestamp, Pageable pageable);
 }

--- a/src/test/java/cafeLogProject/cafeLog/service/reviewService/FindFollowingUsersReviewTest.java
+++ b/src/test/java/cafeLogProject/cafeLog/service/reviewService/FindFollowingUsersReviewTest.java
@@ -1,0 +1,388 @@
+package cafeLogProject.cafeLog.service.reviewService;
+
+import cafeLogProject.cafeLog.api.cafe.dto.SaveCafeReq;
+import cafeLogProject.cafeLog.api.cafe.service.CafeService;
+import cafeLogProject.cafeLog.api.follow.service.FollowService;
+import cafeLogProject.cafeLog.api.review.dto.ShowReviewResponse;
+import cafeLogProject.cafeLog.api.review.dto.ShowUserReviewRequest;
+import cafeLogProject.cafeLog.api.review.service.ReviewService;
+import cafeLogProject.cafeLog.domains.cafe.repository.CafeRepository;
+import cafeLogProject.cafeLog.domains.review.domain.Review;
+import cafeLogProject.cafeLog.domains.review.repository.ReviewRepository;
+import cafeLogProject.cafeLog.domains.user.domain.User;
+import cafeLogProject.cafeLog.domains.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(properties = "classpath:application-test.yml")
+@ActiveProfiles("test")
+@Transactional
+public class FindFollowingUsersReviewTest {
+
+    @Autowired
+    ReviewService reviewService;
+    @Autowired
+    CafeService cafeService;
+    @Autowired
+    CafeRepository cafeRepository;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    FollowService followService;
+    @Autowired
+    ReviewRepository reviewRepository;
+
+    @Test
+    @DisplayName("팔로우한 사용자의 리뷰만 조회된다")
+    public void findFollowingUsersReviewsSuccess() {
+        // given
+        User follower = userRepository.save(User.builder()
+                .username("follower")
+                .nickname("팔로워")
+                .build());
+
+        User following = userRepository.save(User.builder()
+                .username("following")
+                .nickname("팔로잉")
+                .build());
+
+        User notFollowing = userRepository.save(User.builder()
+                .username("notFollowing")
+                .nickname("미팔로잉")
+                .build());
+
+        Long cafeId = cafeService.saveCafe(SaveCafeReq.builder()
+                .title("테스트카페")
+                .category("카페")
+                .roadAddress("도로명주소")
+                .mapx("1111")
+                .mapy("2222")
+                .address("주소")
+                .link("링크")
+                .build());
+
+        followService.followUser(follower.getUsername(), following.getId());
+
+        Review followingReview = reviewRepository.save(Review.builder()
+                .content("팔로잉한 유저의 리뷰")
+                .rating(5)
+                .visitDate(LocalDate.now())
+                .cafe(cafeRepository.findById(cafeId).get())
+                .user(following)
+                .build());
+
+        Review notFollowingReview = reviewRepository.save(Review.builder()
+                .content("팔로잉하지 않은 유저의 리뷰")
+                .rating(5)
+                .visitDate(LocalDate.now())
+                .cafe(cafeRepository.findById(cafeId).get())
+                .user(notFollowing)
+                .build());
+
+        // when 
+        ShowUserReviewRequest request = ShowUserReviewRequest.builder()
+                .limit(10)
+                .timestamp(LocalDateTime.now().plusYears(1))
+                .build();
+
+        List<ShowReviewResponse> result = reviewService.findFollowingUsersReviews(
+                follower.getUsername(),
+                request
+        );
+
+        // then
+        assertThat(result).hasSize(1); // 팔로우한 유저의 리뷰만 1개
+        ShowReviewResponse response = result.getFirst();
+        assertThat(response.getContent()).isEqualTo("팔로잉한 유저의 리뷰");
+        assertThat(response.getUserId()).isEqualTo(following.getId());
+        assertThat(response.getNickname()).isEqualTo(following.getNickname());
+    }
+
+    @Test
+    @DisplayName("팔로우한 사용자의 리뷰가 생성일자 기준 최신순으로 정렬된다")
+    public void findFollowingUsersReviewsSortedByCreatedAtDesc() {
+        // given
+        User follower = userRepository.save(User.builder()
+                .username("follower")
+                .nickname("팔로워")
+                .build());
+
+        User following = userRepository.save(User.builder()
+                .username("following")
+                .nickname("팔로잉")
+                .build());
+
+        Long cafeId = cafeService.saveCafe(SaveCafeReq.builder()
+                .title("테스트카페")
+                .category("카페")
+                .roadAddress("도로명주소")
+                .mapx("1111")
+                .mapy("2222")
+                .address("주소")
+                .link("링크")
+                .build());
+
+        followService.followUser(follower.getUsername(), following.getId());
+
+        // 팔로잉유저가 리뷰 3개 작성 (시간차를 두고)
+        Review oldestReview = reviewRepository.save(Review.builder()
+                .content("가장 오래된 리뷰")
+                .rating(5)
+                .visitDate(LocalDate.now())
+                .cafe(cafeRepository.findById(cafeId).get())
+                .user(following)
+                .build());
+
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        Review middleReview = reviewRepository.save(Review.builder()
+                .content("중간 리뷰")
+                .rating(5)
+                .visitDate(LocalDate.now())
+                .cafe(cafeRepository.findById(cafeId).get())
+                .user(following)
+                .build());
+
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        Review latestReview = reviewRepository.save(Review.builder()
+                .content("가장 최근 리뷰")
+                .rating(5)
+                .visitDate(LocalDate.now())
+                .cafe(cafeRepository.findById(cafeId).get())
+                .user(following)
+                .build());
+
+        // when
+        ShowUserReviewRequest request = ShowUserReviewRequest.builder()
+                .limit(10)
+                .timestamp(LocalDateTime.now().plusYears(1))
+                .build();
+
+        List<ShowReviewResponse> result = reviewService.findFollowingUsersReviews(
+                follower.getUsername(),
+                request
+        );
+
+        // then
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).getContent()).isEqualTo("가장 최근 리뷰");
+        assertThat(result.get(1).getContent()).isEqualTo("중간 리뷰");
+        assertThat(result.get(2).getContent()).isEqualTo("가장 오래된 리뷰");
+    }
+
+    @Test
+    @DisplayName("팔로우한 사용자가 없는 경우 빈 리스트가 반환된다")
+    public void returnEmptyListWhenNoFollowing() {
+        // given
+        User user = userRepository.save(User.builder()
+                .username("user")
+                .nickname("유저")
+                .build());
+
+        // when
+        ShowUserReviewRequest request = ShowUserReviewRequest.builder()
+                .limit(10)
+                .timestamp(LocalDateTime.now().plusYears(1))
+                .build();
+
+        List<ShowReviewResponse> result = reviewService.findFollowingUsersReviews(
+                user.getUsername(),
+                request
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("주어진 timestamp 이전의 리뷰만 조회된다")
+    public void findReviewsBeforeTimestamp() {
+        // given
+        User follower = userRepository.save(User.builder()
+                .username("follower")
+                .nickname("팔로워")
+                .build());
+
+        User following = userRepository.save(User.builder()
+                .username("following")
+                .nickname("팔로잉")
+                .build());
+
+        Long cafeId = cafeService.saveCafe(SaveCafeReq.builder()
+                .title("테스트카페")
+                .category("카페")
+                .roadAddress("도로명주소")
+                .mapx("1111")
+                .mapy("2222")
+                .address("주소")
+                .link("링크")
+                .build());
+
+        followService.followUser(follower.getUsername(), following.getId());
+
+        // 리뷰 3개 작성 (시간차를 두고)
+        Review oldReview = reviewRepository.save(Review.builder()
+                .content("오래된 리뷰")
+                .rating(5)
+                .visitDate(LocalDate.now())
+                .cafe(cafeRepository.findById(cafeId).get())
+                .user(following)
+                .build());
+
+        // 1초 대기
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        LocalDateTime timestamp = LocalDateTime.now(); // 중간 시점 timestamp 저장
+
+        // 1초 대기
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        Review newReview = reviewRepository.save(Review.builder()
+                .content("최근 리뷰")
+                .rating(5)
+                .visitDate(LocalDate.now())
+                .cafe(cafeRepository.findById(cafeId).get())
+                .user(following)
+                .build());
+
+        // when
+        ShowUserReviewRequest request = ShowUserReviewRequest.builder()
+                .limit(10)
+                .timestamp(timestamp)
+                .build();
+
+        List<ShowReviewResponse> result = reviewService.findFollowingUsersReviews(
+                follower.getUsername(),
+                request
+        );
+
+        // then
+        assertThat(result).hasSize(1); // timestamp 이전의 리뷰만 1개
+        ShowReviewResponse response = result.get(0);
+        assertThat(response.getContent()).isEqualTo("오래된 리뷰");
+        assertThat(response.getUserId()).isEqualTo(following.getId());
+        assertThat(response.getCreatedAt()).isBefore(timestamp);
+    }
+
+    @Test
+    @DisplayName("pageable의 size만큼만 리뷰가 조회된다")
+    public void findReviewsLimitedByPageSize() {
+        // given
+        User follower = userRepository.save(User.builder()
+                .username("follower")
+                .nickname("팔로워")
+                .build());
+
+        User following = userRepository.save(User.builder()
+                .username("following")
+                .nickname("팔로잉")
+                .build());
+
+        Long cafeId = cafeService.saveCafe(SaveCafeReq.builder()
+                .title("테스트카페")
+                .category("카페")
+                .roadAddress("도로명주소")
+                .mapx("1111")
+                .mapy("2222")
+                .address("주소")
+                .link("링크")
+                .build());
+
+        followService.followUser(follower.getUsername(), following.getId());
+
+        for (int i = 1; i <= 5; i++) {
+            reviewRepository.save(Review.builder()
+                    .content("리뷰 " + i)
+                    .rating(5)
+                    .visitDate(LocalDate.now())
+                    .cafe(cafeRepository.findById(cafeId).get())
+                    .user(following)
+                    .build());
+
+            // 시간 차이를 주기 위해 대기
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        // when
+        ShowUserReviewRequest request = ShowUserReviewRequest.builder()
+                .limit(3)
+                .timestamp(LocalDateTime.now().plusYears(1))
+                .build();
+
+        List<ShowReviewResponse> result = reviewService.findFollowingUsersReviews(
+                follower.getUsername(),
+                request
+        );
+
+        // then
+        assertThat(result).hasSize(3);
+
+        // 최신순으로 정렬되어 있는지 확인
+        assertThat(result.get(0).getContent()).isEqualTo("리뷰 5");
+        assertThat(result.get(1).getContent()).isEqualTo("리뷰 4");
+        assertThat(result.get(2).getContent()).isEqualTo("리뷰 3");
+    }
+
+    @Test
+    @DisplayName("팔로우한 사용자의 리뷰가 없는 경우 빈 리스트가 반환된다")
+    public void returnEmptyListWhenFollowingHasNoReviews() {
+        // given
+        User follower = userRepository.save(User.builder()
+                .username("follower")
+                .nickname("팔로워")
+                .build());
+
+        User following = userRepository.save(User.builder()
+                .username("following")
+                .nickname("팔로잉")
+                .build());
+
+        followService.followUser(follower.getUsername(), following.getId());
+
+        // when
+        ShowUserReviewRequest request = ShowUserReviewRequest.builder()
+                .limit(10)
+                .timestamp(LocalDateTime.now().plusYears(1))
+                .build();
+
+        List<ShowReviewResponse> result = reviewService.findFollowingUsersReviews(
+                follower.getUsername(),
+                request
+        );
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}


### PR DESCRIPTION
# 변경사항
## 기능 설명
- 사용자가 팔로우하는 다른 사용자들의 리뷰를 조회하는 API 기능 구현

## 구현 상세
### 1. 컨트롤러 계층
- ReviewController에 `/follow` 엔드포인트 추가
- 인증된 사용자가 자신이 팔로우하는 사용자들의 리뷰 목록을 조회할 수 있음
- 페이징과 timestamp 기반 커서 지원

### 2. 서비스 계층
- ReviewService에 `findFollowingUsersReviews` 메소드 추가
- 사용자 인증 및 유효성 검사 수행
- 팔로잉 사용자 리뷰 조회를 위한 레포지토리 메소드 호출

### 3. 데이터 접근 계층
- ReviewRepositoryCustom 인터페이스에 `searchByFollowingUsers` 메소드 추가
- ReviewRepositoryCustomImpl에 메소드 구현
  - 팔로잉 ID 목록 조회
  - 리뷰 ID 목록 조회 (필터링 및 정렬 적용)
  - 리뷰 및 관련 데이터 조회 (카페, 사용자, 태그, 이미지 정보 포함)
  - 생성일 기준 내림차순 정렬

## 테스트 방법
1. 사용자 로그인
2. GET /api/reviews/follow 엔드포인트로 요청
3. limit과 timestamp 파라미터 전달 가능
4. JSON 형식의 팔로잉 사용자 리뷰 목록 반환 확인

## 체크리스트
- [x] 테스트 코드를 작성하였습니까?
- [x] 타입 안정성을 검증하였습니까?
- [x] 코드 컨벤션을 준수하였습니까?
- [x] 관련 문서를 업데이트하였습니까?
- [x] 사용자 경험을 고려하였습니까?

## 추가 설명
### Known Issues
- 팔로잉 사용자가 많을 경우 성능 이슈가 발생할 수 있음 (추후 인덱싱 개선 필요)