### PR TITLE
feat: Add Search User By Nickname API

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/controller/UserController.java
@@ -11,7 +11,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 
 @RestController
 @RequestMapping("/api")
@@ -44,18 +43,19 @@ public class UserController {
         return ResponseEntity.ok(isExist);
     }
 
-    @GetMapping("/profile/search")
-    public ResponseEntity<List<UserSearchRes>> searchUsersByNickname(@RequestParam String name) {
-
-        List<UserSearchRes> userSearchRes = userService.searchUsersByNickname(name);
-        return ResponseEntity.ok(userSearchRes);
-    }
-
     @GetMapping("/users/{userId}")
     public ResponseEntity<OtherUserInfoRes> getOtherUserInfo(@AuthenticationPrincipal CustomOAuth2User user,
                                                              @PathVariable Long userId) {
 
         OtherUserInfoRes otherUserInfo = userService.getOtherUserInfo(user.getName(), userId);
         return ResponseEntity.ok(otherUserInfo);
+    }
+
+    @GetMapping("/profile/search")
+    public ResponseEntity<List<UserSearchRes>> searchUserByNickname(@RequestParam String nickname,
+                                                                    @AuthenticationPrincipal CustomOAuth2User user) {
+
+        List<UserSearchRes> userSearchRes = userService.searchUserByNickname(nickname, user.getName());
+        return ResponseEntity.ok(userSearchRes);
     }
 }

--- a/src/main/java/cafeLogProject/cafeLog/api/user/dto/UserSearchRes.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/dto/UserSearchRes.java
@@ -1,5 +1,6 @@
 package cafeLogProject.cafeLog.api.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,15 +10,22 @@ import lombok.NoArgsConstructor;
 public class UserSearchRes {
 
     private Long userId;
+
     private String nickname;
-    private String introduce;
+
+    private Boolean isProfileImageExist;
+
+    @JsonProperty("isFollow")
+    private int isFollow;
+
+    private String followerCountMessage;
 
     @QueryProjection
-    public UserSearchRes(Long userId, String nickname, String introduce) {
+    public UserSearchRes(Long userId, String nickname, Boolean isProfileImageExist) {
 
         this.userId = userId;
         this.nickname = nickname;
-        this.introduce = introduce;
+        this.isProfileImageExist = isProfileImageExist;
     }
 
 }

--- a/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/user/service/UserService.java
@@ -2,9 +2,7 @@ package cafeLogProject.cafeLog.api.user.service;
 
 import cafeLogProject.cafeLog.api.user.dto.*;
 import cafeLogProject.cafeLog.common.auth.jwt.JWTUserDTO;
-import cafeLogProject.cafeLog.common.auth.oauth2.CustomOAuth2User;
 import cafeLogProject.cafeLog.common.exception.user.UserNicknameException;
-import cafeLogProject.cafeLog.common.exception.user.UserNicknameNullException;
 import cafeLogProject.cafeLog.common.exception.user.UserNotFoundException;
 import cafeLogProject.cafeLog.domains.review.repository.ReviewRepository;
 import cafeLogProject.cafeLog.domains.user.domain.User;
@@ -15,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 import static cafeLogProject.cafeLog.common.exception.ErrorCode.*;
 
@@ -57,19 +54,22 @@ public class UserService {
         return new IsExistNicknameRes(nickname, true);
     }
 
-    public List<UserSearchRes> searchUsersByNickname(String nickname) {
-
-        if (nickname == null || nickname.trim().isEmpty()) {
-            throw new UserNicknameNullException(USER_NICKNAME_NULL_ERROR);
-        }
-
-        return userRepository.findByNicknameContainingIgnoreCase(nickname);
-    }
-
     public OtherUserInfoRes getOtherUserInfo(String currentUsername, Long otherUserId) {
 
         return userRepository.findOtherUserInfo(currentUsername, otherUserId)
                 .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+    }
+
+    public List<UserSearchRes> searchUserByNickname(String searchNickname, String currentUsername) {
+
+        if (searchNickname == null || searchNickname.trim().isEmpty()) {
+            throw new UserNicknameException(USER_NICKNAME_NULL_ERROR);
+        }
+
+        User user = userRepository.findByUsername(currentUsername)
+                .orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND_ERROR));
+
+        return userRepository.searchUserByNickname(searchNickname, user.getId());
     }
 
     private void validateNickname(String userName, UserUpdateReq userUpdateReq) {

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryCustom.java
@@ -10,7 +10,8 @@ import java.util.Optional;
 public interface UserRepositoryCustom {
 
     boolean existsNicknameExcludingSelf(String username, String newNickname);
-    List<UserSearchRes> findByNicknameContainingIgnoreCase(String nickname);
     Optional<OtherUserInfoRes> findOtherUserInfo(String currentUsername, Long otherUserId);
     Optional<UserInfoRes> findMyProfileWithReviewCount(String username);
+
+    List<UserSearchRes> searchUserByNickname(String searchNickname, Long currentUserId);
 }

--- a/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/user/repository/UserRepositoryImpl.java
@@ -1,16 +1,14 @@
 package cafeLogProject.cafeLog.domains.user.repository;
 
 import cafeLogProject.cafeLog.api.user.dto.*;
-import cafeLogProject.cafeLog.domains.follow.domain.QFollow;
-import cafeLogProject.cafeLog.domains.review.domain.QReview;
+import com.querydsl.core.Tuple;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static cafeLogProject.cafeLog.domains.follow.domain.QFollow.follow;
-import static cafeLogProject.cafeLog.domains.review.domain.QReview.*;
+import static cafeLogProject.cafeLog.domains.review.domain.QReview.review;
 import static cafeLogProject.cafeLog.domains.user.domain.QUser.user;
 
 @RequiredArgsConstructor
@@ -26,20 +24,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
                 .where(user.nickname.eq(newNickname)
                         .and(user.username.ne(username)))
                 .fetchOne() != null;
-    }
-
-    @Override
-    public List<UserSearchRes> findByNicknameContainingIgnoreCase(String nickname) {
-
-        return queryFactory
-                .select(new QUserSearchRes(
-                        user.id,
-                        user.nickname,
-                        user.introduce
-                ))
-                .from(user)
-                .where(user.nickname.startsWith(nickname))
-                .fetch();
     }
 
     @Override
@@ -93,5 +77,114 @@ public class UserRepositoryImpl implements UserRepositoryCustom{
         return Optional.ofNullable(reviewCnt);
     }
 
+    /**
+     *
+     * @param searchNickname 검색하려는 닉네임
+     * @param currentUserId 현재 로그인한 사용자
+     *
+     * searchList -> searchNickname을 자신의 닉네임에 포함하고 있는 유저들 리스트
+     * myFollowingList -> 현재 로그인한 사용자의 팔로잉 리스트
+     * mutualFollowers -> searchList로 나온 유저의 팔로워 리스트에도 존재하고 현재 로그인한 사용자의 팔로잉 리스트에도 존재하는 유저들 닉네임
+     * mutualFollowersMap -> mutualFollowers 정리
+     *                      => Map<searchList로 나온 유저 아이디, List<searchList로 나온 유저의 팔로워 리스트에도 존재하고 현재 로그인한 사용자의 팔로잉 리스트에도 존재하는 유저들 닉네임>>
+     *
+     * @method setIsFollow -> 현재 로그인한 사용자가 searchList로 나온 유저를 팔로잉 하고 있는지 여부
+     * @method setFollowerCountMessage -> mutualFollowersMap에서 나온 정보를 기반으로 사용자에게 적절한 메시지 설정
+     * @method sortSearchList -> searchList 정렬
+     *                          1) searchNickname 을 닉네임으로 가진 유저
+     *                          2) 겹치는 팔로우들의 수(=List<searchList로 나온 유저의 팔로워 리스트에도 존재하고 현재 로그인한 사용자의 팔로잉 리스트에도 존재하는 유저들 닉네임>.size())
+     *
+     */
+    @Override
+    public List<UserSearchRes> searchUserByNickname(String searchNickname, Long currentUserId) {
+
+        List<UserSearchRes> searchList = queryFactory
+                .select(new QUserSearchRes(
+                        user.id,
+                        user.nickname,
+                        user.isImageExist
+                ))
+                .from(user)
+                .where(user.nickname.containsIgnoreCase(searchNickname))
+                .fetch();
+
+        List<Long> myFollowingList = queryFactory
+                .select(follow.following.id)
+                .from(follow)
+                .where(follow.follower.id.eq(currentUserId))
+                .fetch();
+
+        List<Tuple> mutualFollowers = queryFactory
+                .select(follow.following.id, follow.follower.nickname)
+                .from(follow)
+                .join(user).on(follow.following.id.eq(user.id))
+                .where(user.nickname.containsIgnoreCase(searchNickname))
+                .where(follow.follower.id.in(myFollowingList))
+                .fetch();
+
+        Map<Long, List<String>> mutualFollowersMap = new HashMap<>();
+
+        for (Tuple followerResult : mutualFollowers) {
+            Long followingUserId = followerResult.get(0, Long.class);
+            String followerNickname = followerResult.get(1, String.class);
+
+            mutualFollowersMap
+                    .computeIfAbsent(followingUserId, id -> new ArrayList<>())
+                    .add(followerNickname);
+        }
+
+
+        searchList.forEach(searchedUser -> {
+            setIsFollow(currentUserId, searchedUser, myFollowingList);
+            setFollowerCountMessage(searchedUser, mutualFollowersMap);
+        });
+
+        sortSearchList(searchNickname, searchList, mutualFollowersMap);
+
+        return searchList
+                .stream()
+                .limit(10)
+                .toList();
+
+    }
+
+    private void setIsFollow(Long currentUserId, UserSearchRes searchedUser, List<Long> myFollowingList) {
+        if (searchedUser.getUserId().equals(currentUserId)) {
+            searchedUser.setIsFollow(2);
+        } else if (myFollowingList.contains(searchedUser.getUserId())) {
+            searchedUser.setIsFollow(1);
+        } else {
+            searchedUser.setIsFollow(0);
+        }
+    }
+
+    private void setFollowerCountMessage(UserSearchRes searchedUser, Map<Long, List<String>> mutualFollowersMap) {
+        List<String> commonFollow = mutualFollowersMap.get(searchedUser.getUserId());
+        if (commonFollow != null && !commonFollow.isEmpty()) {
+            if (searchedUser.getIsFollow() != 2) {
+                if (commonFollow.size() > 1) {
+                    searchedUser.setFollowerCountMessage(commonFollow.get(0) + "님 외 " + (commonFollow.size() - 1) + "명이 팔로우합니다.");
+                } else {
+                    searchedUser.setFollowerCountMessage(commonFollow.get(0) + "님이 팔로우합니다.");
+                }
+            }
+        }
+    }
+
+    private void sortSearchList(String searchNickname, List<UserSearchRes> searchList, Map<Long, List<String>> mutualFollowersMap) {
+        Collections.sort(searchList, (user1, user2) -> {
+
+            boolean isUser1Matched = user1.getNickname().equalsIgnoreCase(searchNickname);
+            boolean isUser2Matched = user2.getNickname().equalsIgnoreCase(searchNickname);
+
+            if (isUser1Matched) return -1;
+            if (isUser2Matched) return 1;
+
+            int size1 = Optional.ofNullable(mutualFollowersMap.get(user1.getUserId())).map(List::size).orElse(0);
+            int size2 = Optional.ofNullable(mutualFollowersMap.get(user2.getUserId())).map(List::size).orElse(0);
+
+            return Integer.compare(size2, size1);
+        });
+    }
 
 }


### PR DESCRIPTION
## 변경 사항

- 닉네임으로 유저 검색 API
  - 검색하려는 닉네임이 포함된 유저

- 팔로워,팔로잉 리스트 조회 API 레디스 키 구분
  - (currentUserId:otherUserId)  --> (currentUserId:otherUserId-follower), (currentUserId:otherUserId-following)
 