### PR TITLE
fix: 이미지 조회 api 수정 : last modified 관련 304 버그 수정

### DIFF
--- a/src/main/java/cafeLogProject/cafeLog/api/image/controller/DraftReviewImageController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/image/controller/DraftReviewImageController.java
@@ -54,6 +54,7 @@ public class DraftReviewImageController {
         }
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CACHE_CONTROL, "no-cache")
                 .header(HttpHeaders.LAST_MODIFIED, lastModifiedDate.format(DateTimeFormatter.RFC_1123_DATE_TIME))
                 .body(resource);
     }

--- a/src/main/java/cafeLogProject/cafeLog/api/image/controller/ProfileImageController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/image/controller/ProfileImageController.java
@@ -52,6 +52,7 @@ public class ProfileImageController {
         }
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CACHE_CONTROL, "no-cache")
                 .header(HttpHeaders.LAST_MODIFIED, lastModifiedDate.format(DateTimeFormatter.RFC_1123_DATE_TIME))
                 .body(resource);
     }

--- a/src/main/java/cafeLogProject/cafeLog/api/image/controller/ReviewImageController.java
+++ b/src/main/java/cafeLogProject/cafeLog/api/image/controller/ReviewImageController.java
@@ -53,6 +53,7 @@ public class ReviewImageController {
         }
         return ResponseEntity.ok()
                 .contentType(MediaType.parseMediaType(contentType))
+                .header(HttpHeaders.CACHE_CONTROL, "no-cache")
                 .header(HttpHeaders.LAST_MODIFIED, lastModifiedDate.format(DateTimeFormatter.RFC_1123_DATE_TIME))
                 .body(resource);
     }

--- a/src/main/java/cafeLogProject/cafeLog/domains/image/util/ImageHandler.java
+++ b/src/main/java/cafeLogProject/cafeLog/domains/image/util/ImageHandler.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 
 // 이미지 파일 서버 로컬 스토리지에 저장/불러오기
 @Slf4j
@@ -96,7 +97,7 @@ public class ImageHandler {
             File file = resource.getFile();
             Long lastModifiedNum = file.lastModified();
             if (lastModifiedNum == 0) throw new ImageLoadException("알 수 없는 원인으로 인해 lastModified값이 0입니다.", ErrorCode.IMAGE_LOAD_ERROR);
-            ZonedDateTime lastModifiedDate = Instant.ofEpochMilli(lastModifiedNum).atZone(ZoneId.systemDefault());
+            ZonedDateTime lastModifiedDate = Instant.ofEpochMilli(lastModifiedNum).atZone(ZoneId.of("UTC")).truncatedTo(ChronoUnit.SECONDS);
             return lastModifiedDate;
         } catch (Exception e) {
             // 다른 저장소 (예: S3)에서 로드된 경우 (URL 리소스 처리하는 경우) 별도 처리 필요


### PR DESCRIPTION
# 변경사항

## 기능 설명
<!-- 구현한 기능에 대한 간단한 설명을 작성해주세요 -->
- 프론트에서 이미지 조회 요청시  If-Modified-Since값과 Last-Modified값이 같아도 304가 아닌 200 응답 받는 버그 수정
- 프론트에서 이미지 로드시 무조건 매번 조회 api 요청 보내도록 설정

## 구현 상세
<!-- 주요 구현 내용과 구현 방식에 대해 설명해주세요 -->
### 1.  If-Modified-Since값과 Last-Modified값 비교시 발생한 오류 수정
- If-Modified-Since값과 Last-Modified 값의 위치 시간대가 달라 문제가 발생했습니다.
```powershell
# 브라우저 요청의 if-Modified-Since 값
Tue, 25 Feb 2025 03:56:36 GMT
# 서버 파일의 Last-Modified 값
2025-02-25T12:56:36[Asia/Seoul]
``` 
- atZone(ZoneId.of("UTC"))를 통해 위치 시간대 통일
- truncatedTo(ChronoUnit.SECONDS)를 통해 밀리초를 제거
```java
ZonedDateTime lastModifiedDate = Instant.ofEpochMilli(lastModifiedNum).atZone(ZoneId.of("UTC")).truncatedTo(ChronoUnit.SECONDS);
``` 

### 2. 응답의 헤더값에 "no cache" 넣도록 수정
- "no cache"를 추가하여 프론트에서 매번 api 요청을 보내어 304 여부를 확인하도록 합니다.
- 이를 통해 이미 이미지가 브라우저 캐시에 저장되어있어도 중간에 수정/삭제 되지는 않았는지 재확인하도록 합니다.
```java
        return ResponseEntity.ok()
                .contentType(MediaType.parseMediaType(contentType))
                .header(HttpHeaders.CACHE_CONTROL, "no-cache")        // "no cache" 입력
                .header(HttpHeaders.LAST_MODIFIED, lastModifiedDate.format(DateTimeFormatter.RFC_1123_DATE_TIME))
                .body(resource);
``` 

## 관련 PR
<!-- 관련된 이슈 번호를 링크해주세요 -->
- 기존 코드 #76 

## 테스트 방법
<!-- 테스트 시나리오를 구체적으로 작성해주세요 -->
1. 이미지 처음 조회시 개발자도구의 Network의 Headers에서 아래와 같이 200 응답을 받는지 확인
![image](https://github.com/user-attachments/assets/77b675fc-0318-45bc-b910-bbbb063a2cf8)

2. 이미지 두번째 조회시 개발자도구의 Network의 Headers에서 아래와 같이 304 응답을 받는지 확인
![image](https://github.com/user-attachments/assets/a15ac379-f442-4303-948e-9d075fff42d1)


## 추가 설명
<!-- 리뷰어가 참고해야 할 내용이나 우려사항을 작성해주세요 -->
### Known Issues
- 개발자 도구의 Network로 304여부 확인할 때 아래의 "Disable cache"를 비활성화해주세요. 
  활성화된 경우 브라우저캐시를 사용하지 않아 항상 200 응답을 받습니다.
![image](https://github.com/user-attachments/assets/b341ff29-f7a0-4db6-bdcb-b88cd6ef0056)


